### PR TITLE
Add package.json to exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,10 @@
   ],
   "sideEffects": false,
   "type": "module",
-  "exports": "./index.js",
+  "exports": {
+    ".": "./index.js",
+    "./package.json": "./package.json"
+  },
   "files": [
     "lib/",
     "index.d.ts",


### PR DESCRIPTION
@arethetypeswrong/history includes the npm-high-impact version used to generate its data, so being able to access the package.json via import/require is convenient 😄