### PR TITLE
Make `script/crawl-top-download-{,un}scoped.js` resumable & accept CLI parameters

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,10 +5,7 @@
 .DS_Store
 .env
 coverage/
-data/download-counts-scoped.json
-data/download-counts-unscoped.json
-data/packages.txt
-data/sequence.txt
-data/top-dependent.json
+data/*
+!data/.gitkeep
 node_modules/
 yarn.lock

--- a/package.json
+++ b/package.json
@@ -9,7 +9,6 @@
     "c8": "^10.0.0",
     "changes-stream": "^2.0.0",
     "dotenv": "^16.0.0",
-    "minimist": "^1.2.8",
     "prettier": "^3.0.0",
     "remark-cli": "^12.0.0",
     "remark-preset-wooorm": "^11.0.0",

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "c8": "^10.0.0",
     "changes-stream": "^2.0.0",
     "dotenv": "^16.0.0",
+    "minimist": "^1.2.8",
     "prettier": "^3.0.0",
     "remark-cli": "^12.0.0",
     "remark-preset-wooorm": "^11.0.0",

--- a/readme.md
+++ b/readme.md
@@ -167,6 +167,14 @@ sad).
 After filtering,
 the interesting data would result in about 6k packages.
 
+These scripts support the following options:
+* `--time` - Time period for download counts (default: `last-week`). 
+  Valid values include npm's supported ranges like `last-day`, `last-week`, `last-month`, or specific dates.
+* `--min` - Minimum number of dependents/downloads to include (default: `500`).
+
+The scripts are resumable - if interrupted, they will write progress to `data/download-counts-{scoped,unscoped}.last.json` 
+and can be resumed from where they left off on the next run.
+
 It crawls the npm [package download count API][github-npm-api].
 Unscoped packages are crawled using the batch API to get 128 per request.
 Scoped packages are crawled with 20 HTTP requests at a time,
@@ -185,8 +193,12 @@ packages.
 
 It crawls the `libraries.io` [project search API][libraries-io-api],
 whose results can also [be browsed on the web][libraries-io-web].
+
+The script supports the following option:
+* `--min` - Minimum number of packages that must depend on a package to include it (default: `500`).
+
 Crawling stops paginating when a package is seen that is depended on by less
-than 500 other packages.
+than the specified minimum.
 
 You need an API key for `libraries.io`,
 see their API docs for more info.

--- a/script/crawl-top-dependent.js
+++ b/script/crawl-top-dependent.js
@@ -35,6 +35,7 @@ import fs from 'node:fs/promises'
 import process from 'node:process'
 import {fetch} from 'undici'
 import dotenv from 'dotenv'
+import {argv} from './crawl-top-tools.js'
 
 dotenv.config()
 
@@ -46,13 +47,9 @@ if (!key) {
   )
 }
 
-import { minimist } from 'minimist'
-const argv = minimist(process.argv.slice(2), {
-  default: { min: 500 }
-});
 
 // Stop when packages are depended on by less than this number of packages.
-const { min } = argv
+const {min} = argv
 const destination = new URL('../data/top-dependent.json', import.meta.url)
 let page = 0 // First page is `1`.
 

--- a/script/crawl-top-dependent.js
+++ b/script/crawl-top-dependent.js
@@ -46,8 +46,13 @@ if (!key) {
   )
 }
 
+import { minimist } from 'minimist'
+const argv = minimist(process.argv.slice(2), {
+  default: { min: 500 }
+});
+
 // Stop when packages are depended on by less than this number of packages.
-const min = 500
+const { min } = argv
 const destination = new URL('../data/top-dependent.json', import.meta.url)
 let page = 0 // First page is `1`.
 

--- a/script/crawl-top-dependent.js
+++ b/script/crawl-top-dependent.js
@@ -47,7 +47,6 @@ if (!key) {
   )
 }
 
-
 // Stop when packages are depended on by less than this number of packages.
 const {min} = argv
 const destination = new URL('../data/top-dependent.json', import.meta.url)

--- a/script/crawl-top-download-scoped.js
+++ b/script/crawl-top-download-scoped.js
@@ -8,6 +8,7 @@
  */
 
 import fs from 'node:fs/promises'
+import {fetch} from 'undici'
 import {configure, resume, argv} from './crawl-top-tools.js'
 
 let slice = 0

--- a/script/crawl-top-download-scoped.js
+++ b/script/crawl-top-download-scoped.js
@@ -8,7 +8,7 @@
  */
 
 import fs from 'node:fs/promises'
-import {configure,resume,argv} from './crawl-top-tools.js'
+import {configure, resume, argv} from './crawl-top-tools.js'
 
 let slice = 0
 const destination = new URL(
@@ -18,7 +18,7 @@ const destination = new URL(
 const input = new URL('../data/packages.txt', import.meta.url)
 const allTheNames = String(await fs.readFile(input)).split('\n')
 
-const { last, lastpath } = await resume({ type: 'scoped' })
+const {last, lastpath} = await resume({type: 'scoped'})
 let caughtUp = !last
 if (last) {
   console.log('Resume from last package: %s', last.name)
@@ -29,7 +29,7 @@ const scoped = []
 for (const name of allTheNames) {
   if (!caughtUp) {
     caughtUp = name === last.name
-    continue;
+    continue
   }
 
   if (name.charAt(0) === '@') {
@@ -37,9 +37,9 @@ for (const name of allTheNames) {
   }
 }
 
-if (!scoped.length) {
+if (scoped.length === 0) {
   if (last) console.log('No scoped packages found after %s', last.name)
-  process.exit(0);
+  process.exit(0)
 }
 
 /** @type {Array<Result>} */
@@ -77,9 +77,7 @@ while (true) {
         encodeURIComponent(name)
     )
     const response = await fetch(String(url))
-    const text = (
-      await response.text()
-    )
+    const text = await response.text()
 
     /** @type {NpmDownloadResult | NpmDownloadError} */
     let result

--- a/script/crawl-top-download-scoped.js
+++ b/script/crawl-top-download-scoped.js
@@ -9,6 +9,11 @@
 
 import fs from 'node:fs/promises'
 import {fetch} from 'undici'
+import {minimist} from 'minimist'
+
+const argv = minimist(process.argv.slice(2), {
+  default: { time: 'last-week'}
+});
 
 let slice = 0
 const destination = new URL(
@@ -53,7 +58,8 @@ while (true) {
 
   const promises = names.map(async (name) => {
     const url = new URL(
-      'https://api.npmjs.org/downloads/point/last-week/' +
+      'https://api.npmjs.org/downloads/point/' +
+        `${argv.time}/` +
         encodeURIComponent(name)
     )
     const response = await fetch(String(url))

--- a/script/crawl-top-download-unscoped.js
+++ b/script/crawl-top-download-unscoped.js
@@ -19,9 +19,9 @@
 
 import fs from 'node:fs/promises'
 import {fetch} from 'undici'
-import {configure,resume,argv} from './crawl-top-tools.js'
+import {configure, resume, argv} from './crawl-top-tools.js'
 
-const maxsize = 128  // Up to 128 at a time are allowed.
+const maxsize = 128 // Up to 128 at a time are allowed.
 const destination = new URL(
   '../data/download-counts-unscoped.json',
   import.meta.url
@@ -35,7 +35,7 @@ let errorless = 0
 const input = new URL('../data/packages.txt', import.meta.url)
 const allTheNames = String(await fs.readFile(input)).split('\n')
 
-const { last, lastpath } = await resume({ type: 'unscoped' })
+const {last, lastpath} = await resume({type: 'unscoped'})
 let caughtUp = !last
 if (last) {
   console.log('Resume from last package: %s', last.name)
@@ -46,7 +46,7 @@ const unscoped = []
 for (const name of allTheNames) {
   if (!caughtUp) {
     caughtUp = name === last.name
-    continue;
+    continue
   }
 
   if (name.charAt(0) !== '@') {
@@ -79,7 +79,7 @@ while (true) {
   )
 
   const encoded = names.map((d) => encodeURIComponent(d)).join(',')
-  if (encoded.length > 12000) {
+  if (encoded.length > 12_000) {
     console.warn('Encoded names length too long: %s', encoded.length)
     console.warn('Reducing size from %s to %s', size, size / 2)
     size = Math.floor(size / 2)
@@ -94,11 +94,8 @@ while (true) {
     break
   }
 
-
   const url = new URL(
-    'https://api.npmjs.org/downloads/point/' +
-      `${argv.time}/` +
-      encoded
+    'https://api.npmjs.org/downloads/point/' + `${argv.time}/` + encoded
   )
 
   /* eslint-disable no-await-in-loop */

--- a/script/crawl-top-download-unscoped.js
+++ b/script/crawl-top-download-unscoped.js
@@ -19,6 +19,12 @@
 
 import fs from 'node:fs/promises'
 import {fetch} from 'undici'
+import {minimist} from 'minimist'
+
+const argv = minimist(process.argv.slice(2), {
+  default: { time: 'last-week' }
+});
+
 
 let slice = 0
 const size = 128 // Up to 128 at a time are allowed.
@@ -61,7 +67,8 @@ while (true) {
   )
 
   const url = new URL(
-    'https://api.npmjs.org/downloads/point/last-week/' +
+    'https://api.npmjs.org/downloads/point/' +
+      `${argv.time}/` +
       names.map((d) => encodeURIComponent(d)).join(',')
   )
 

--- a/script/crawl-top-tools.js
+++ b/script/crawl-top-tools.js
@@ -3,7 +3,10 @@ import {Agent,interceptors,setGlobalDispatcher} from 'undici'
 import minimist from 'minimist'
 
 export const argv = minimist(process.argv.slice(2), {
-  default: { time: 'last-week' }
+  default: {
+    time: 'last-week',
+    min: 500,
+  }
 });
 
 export function configure() {

--- a/script/crawl-top-tools.js
+++ b/script/crawl-top-tools.js
@@ -1,44 +1,44 @@
 import {join} from 'path'
-import {Agent,interceptors,setGlobalDispatcher} from 'undici'
+import {Agent, interceptors, setGlobalDispatcher} from 'undici'
 import minimist from 'minimist'
 
 export const argv = minimist(process.argv.slice(2), {
   default: {
     time: 'last-week',
-    min: 500,
+    min: 500
   }
-});
+})
 
 export function configure() {
   // Interceptors to add response caching, DNS caching and retrying to the dispatcher
-  const { cache, dns, retry } = interceptors
+  const {cache, dns, retry} = interceptors
 
   const defaultDispatcher = new Agent({
     connections: 100, // Limit concurrent kept-alive connections to not run out of resources
     headersTimeout: 10_000, // 10 seconds; set as appropriate for the remote servers you plan to connect to
-    bodyTimeout: 10_000,
+    bodyTimeout: 10_000
   }).compose(cache(), dns(), retry())
 
   setGlobalDispatcher(defaultDispatcher) // Add these interceptors to all `fetch` and Undici `request` calls
 }
 
-export async function resume({ type = 'scoped' }) {
+export async function resume({type = 'scoped'}) {
   const lastpath = join(
     import.meta.dirname,
     `../data/download-counts-${type}.last.json`
   )
 
   try {
-    const json = await import(`${lastpath}`, { with: { type: 'json' } });
+    const json = await import(`${lastpath}`, {with: {type: 'json'}})
     return {
       last: json.default,
-      lastpath,
+      lastpath
     }
   } catch (err) {
     if (err.code !== 'ERR_MODULE_NOT_FOUND') {
-      console.warn('[%s] Error reading %s: %s', err.code, lastpath, err.message);
+      console.warn('[%s] Error reading %s: %s', err.code, lastpath, err.message)
     }
 
-    return { lastpath };
+    return {lastpath}
   }
 }

--- a/script/crawl-top-tools.js
+++ b/script/crawl-top-tools.js
@@ -1,0 +1,41 @@
+import {join} from 'path'
+import {Agent,interceptors,setGlobalDispatcher} from 'undici'
+import minimist from 'minimist'
+
+export const argv = minimist(process.argv.slice(2), {
+  default: { time: 'last-week' }
+});
+
+export function configure() {
+  // Interceptors to add response caching, DNS caching and retrying to the dispatcher
+  const { cache, dns, retry } = interceptors
+
+  const defaultDispatcher = new Agent({
+    connections: 100, // Limit concurrent kept-alive connections to not run out of resources
+    headersTimeout: 10_000, // 10 seconds; set as appropriate for the remote servers you plan to connect to
+    bodyTimeout: 10_000,
+  }).compose(cache(), dns(), retry())
+
+  setGlobalDispatcher(defaultDispatcher) // Add these interceptors to all `fetch` and Undici `request` calls
+}
+
+export async function resume({ type = 'scoped' }) {
+  const lastpath = join(
+    import.meta.dirname,
+    `../data/download-counts-${type}.last.json`
+  )
+
+  try {
+    const json = await import(`${lastpath}`, { with: { type: 'json' } });
+    return {
+      last: json.default,
+      lastpath,
+    }
+  } catch (err) {
+    if (err.code !== 'ERR_MODULE_NOT_FOUND') {
+      console.warn('[%s] Error reading %s: %s', err.code, lastpath, err.message);
+    }
+
+    return { lastpath };
+  }
+}


### PR DESCRIPTION
@wooorm hi! Long time friend 👋 love the project 🚀🐢✨ it was very helpful recently

I made a few improvements that I wanted to get your feedback on before I spend more time writing docs, fixing ts typehint errors, etc. so please forgive the obvious test & lint failures you see 😅 Will of course fix those up if this makes sense to you conceptually 💪 

The most relevant improvement here is that the longest running scripts – `script/crawl-top-download-{,un}scoped.js` – are now resumable should they fail midway. e.g. 

``` sh
node script/crawl-top-download-unscoped.js --time last-month
Fetching 2243948 unscoped packages in bulk (this’ll take about 8 hours)
fetching unscoped page: 0, collected total: 0
  last: {"downloads":37,"name":"-test-bitbucket-branch-manager","ok":true}
(...)
fetching unscoped page: 593, collected total: 75568
  last: {"downloads":26,"name":"angular-gmaps-initializer","ok":true}

# Kill the program ^C
# Then run it again

node script/crawl-top-download-unscoped.js --time last-month
Resume from last package: angular-gmaps-initializer
Fetching 2167916 unscoped packages in bulk (this’ll take about 8 hours)
fetching unscoped page: 0, collected total: 0
  last: {"downloads":9,"name":"angular-hello-world16","ok":true}
fetching unscoped page: 1, collected total: 128
```

There are also a few other improvements (such as the `--time` param above):  

- Harden how `undici` is being used based on their [production example]
- Ensure that outbound HTTP requests headers are not too long
- Accept `--min` parameter in `script/crawl-top-dependent.js`
- Accept `--time` parameter in `script/crawl-top-download-{,un}scoped.js`
- Add `data/.gitkeep` so `script/*` are turn-key runnable

[production example]: https://undici.nodejs.org/#/examples/?id=using-interceptors-to-add-response-caching-dns-lookup-caching-and-connection-retries